### PR TITLE
Updated the update_existing_blu function to be more robust

### DIFF
--- a/R/update_existing_blu.R
+++ b/R/update_existing_blu.R
@@ -1,13 +1,20 @@
 #' Update existing blu and node_blu database tables
+#' 
+#' @description
+#' Parses additional information from the blu series tags by updating an existing database. Will return the `battery_voltage_v` and `temperature_celsius` of the tag data as new fields in the connected database. 
 #'
-#' @param table_name string
+#' @param table_name string, either 'blu' or 'blu_node'
+#' @param con the connection to your local database
 #' @param payload dataframe column
 #' @param id dataframe column
 #'
-#' @returns
+#' @returns 
 #' @export
 #'
 #' @examples
+#' update_existing_blu('blu', con)
+#' 
+#' 
 update_existing_blu = function(table_name, con) {
   start_time = Sys.time()
 

--- a/R/update_existing_blu.R
+++ b/R/update_existing_blu.R
@@ -12,7 +12,9 @@ update_existing_blu = function(table_name, con) {
   start_time = Sys.time()
 
   df = tbl(con, table_name) |>
-    filter(is.na(battery_voltage_v) == TRUE) |>
+    # filter(is.na(battery_voltage_v) == TRUE) |>
+    filter(if_any(matches("battery_voltage_v"), \(battery_voltage_v)
+                  is.na(battery_voltage_v) == TRUE)) |> #check if column exists, then filter
     filter(LENGTH(as.character(payload)) == 8) |>
     collect()
   # print(head(df))

--- a/man/update_existing_blu.Rd
+++ b/man/update_existing_blu.Rd
@@ -7,12 +7,19 @@
 update_existing_blu(table_name, con)
 }
 \arguments{
-\item{table_name}{string}
+\item{table_name}{string, either 'blu' or 'blu_node'}
+
+\item{con}{the connection to your local database}
 
 \item{payload}{dataframe column}
 
 \item{id}{dataframe column}
 }
 \description{
-Update existing blu and node_blu database tables
+Parses additional information from the blu series tags by updating an existing database. Will return the \code{battery_voltage_v} and \code{temperature_celsius} of the tag data as new fields in the connected database.
+}
+\examples{
+update_existing_blu('blu', con)
+
+
 }


### PR DESCRIPTION
The first time updating the database to parse the blu data, the battery_voltage_v column doesn't exist and the function errors out. This solution checks if the column exists first and then filters out the nas if it exists or skips it if it doesn't exist. Also added additional documentation for the function